### PR TITLE
Fixed insertion bug when generating a command.

### DIFF
--- a/SkEditor/Views/Generators/CommandGenerator.axaml.cs
+++ b/SkEditor/Views/Generators/CommandGenerator.axaml.cs
@@ -34,8 +34,7 @@ public partial class CommandGenerator : AppWindow
 
         if (!string.IsNullOrEmpty(editor.Document.GetText(line.Offset, line.Length)))
         {
-            code.Append("\n\n");
-            editor.CaretOffset += 2;
+            editor.Document.Insert(offset, "\n\n", AnchorMovementType.AfterInsertion);
         }
 
         code.Append($"command /{NameTextBox.Text}:");


### PR DESCRIPTION
Hello there!

This small PR changes the way new lines are inserted when the cursor is not in a new blank line. It was crashing the editor before, as the cursor was moved but the two new lines characters were not yet inserted. (the GUI generator does not have this error as it adds the new lines in the generated code, inserted at the very end)

Also thought about this: what about a method in the ApiVault to insert values in the editor, taking care of all of this? It could be useful for addons adding new generation :)