### PR TITLE
Code parsing & basic refactoring for options and variables

### DIFF
--- a/SkEditor/API/ISkEditorAPI.cs
+++ b/SkEditor/API/ISkEditorAPI.cs
@@ -5,6 +5,7 @@ using SkEditor.Utilities;
 using SkEditor.Views;
 using System;
 using System.Threading.Tasks;
+using SkEditor.Utilities.Files;
 
 namespace SkEditor.API;
 
@@ -21,6 +22,8 @@ public interface ISkEditorAPI
     public bool IsFile(TabViewItem tabItem);
 
     public TextEditor GetTextEditor();
+
+    public OpenedFile? GetOpenedFile();
 
     public TabView GetTabView();
 

--- a/SkEditor/Controls/SideBarControl.axaml.cs
+++ b/SkEditor/Controls/SideBarControl.axaml.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
+using Avalonia.Animation;
 using Avalonia.Controls;
 using Avalonia.Media;
 using CommunityToolkit.Mvvm.Input;
@@ -28,19 +31,35 @@ public partial class SideBarControl : UserControl
         RegisterPanel(ParserPanel);
     }
 
-    public void LoadPanels()
+    public static long TransitionDuration = 100L;
+    public async void LoadPanels()
     {
         foreach (SidebarPanel panel in Panels)
         {
             var btn = CreatePanelButton(panel);
             var content = panel.Content;
             content.Width = 0;
+            content.Opacity = 0;
+
+            content.Transitions = new Transitions() { 
+                new DoubleTransition()
+                {
+                    Property = WidthProperty, 
+                    Duration = TimeSpan.FromMilliseconds(TransitionDuration)
+                }, 
+                new DoubleTransition()
+                {
+                    Property = OpacityProperty, 
+                    Duration = TimeSpan.FromMilliseconds(150)
+                }
+            };
             
-            btn.Command = new RelayCommand(() =>
+            btn.Command = new RelayCommand(async () =>
             {
                 if (_currentPanel == panel)
                 {
                     _currentPanel.Content.Width = 0; // Close current panel
+                    _currentPanel.Content.Opacity = 0;
                     
                     _currentPanel.OnClose();
                     _currentPanel = null;
@@ -55,11 +74,15 @@ public partial class SideBarControl : UserControl
                 {
                     _currentPanel.OnClose();
                     _currentPanel.Content.Width = 0; // Close current panel
+                    _currentPanel.Content.Opacity = 0;
                     _currentPanel = null;
+                    
+                    await Task.Delay((int) TransitionDuration);
                 }
                 
                 _currentPanel = panel;
                 _currentPanel.Content.Width = _currentPanel.DesiredWidth;
+                _currentPanel.Content.Opacity = 1;
                 _currentPanel.OnOpen();
             });
             

--- a/SkEditor/Controls/SideBarControl.axaml.cs
+++ b/SkEditor/Controls/SideBarControl.axaml.cs
@@ -12,6 +12,7 @@ public partial class SideBarControl : UserControl
     private static readonly List<SidebarPanel> Panels = new();
     
     public readonly ExplorerSidebarPanel.ExplorerPanel ProjectPanel = new();
+    public readonly ParserSidebarPanel.ParserPanel ParserPanel = new();
     
     public static void RegisterPanel(SidebarPanel panel)
     {
@@ -24,6 +25,7 @@ public partial class SideBarControl : UserControl
         InitializeComponent();
         
         RegisterPanel(ProjectPanel);
+        RegisterPanel(ParserPanel);
     }
 
     public void LoadPanels()

--- a/SkEditor/Controls/SideBarControl.axaml.cs
+++ b/SkEditor/Controls/SideBarControl.axaml.cs
@@ -59,7 +59,7 @@ public partial class SideBarControl : UserControl
                 }
                 
                 _currentPanel = panel;
-                _currentPanel.Content.Width = 250;
+                _currentPanel.Content.Width = _currentPanel.DesiredWidth;
                 _currentPanel.OnOpen();
             });
             

--- a/SkEditor/Controls/Sidebar/CodeParser/ParserSidebarPanel.axaml
+++ b/SkEditor/Controls/Sidebar/CodeParser/ParserSidebarPanel.axaml
@@ -51,6 +51,27 @@
                                     </Grid>
                                     <Separator Margin="0 3"/>
                                     
+                                    <!-- Function Argument -->
+                                    <StackPanel VerticalAlignment="Top" HorizontalAlignment="Stretch"
+                                                Spacing="10" IsVisible="{Binding HasFunctionArguments}">
+                                        <TextBlock FontSize="18" TextAlignment="Left" HorizontalAlignment="Center" FontWeight="DemiBold" Text="{Binding FunctionArgumentTitle}"/>
+                                        <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch" Margin="5 8">
+                                            <ItemsControl ItemsSource="{Binding FunctionArguments}">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <Grid ColumnDefinitions="*,*,Auto" Margin="0 2">
+                                                            <TextBlock TextAlignment="Left" FontWeight="DemiBold" Text="{Binding Name}"/>
+                                                            <TextBlock Grid.Column="1" TextAlignment="Left" Text="{Binding Type}"/>
+                                                            <Button Height="28" Width="28" Grid.Column="2" Command="{Binding Rename}" Padding="0" ToolTip.Tip="Rename">
+                                                                <ui:SymbolIcon Symbol="Rename" FontSize="20" Margin="0"></ui:SymbolIcon>
+                                                            </Button>
+                                                        </Grid>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </StackPanel>
+                                    </StackPanel>
+                                    
                                     <!-- Variables -->
                                     <StackPanel VerticalAlignment="Top" HorizontalAlignment="Stretch"
                                                 Spacing="10" IsVisible="{Binding HasAnyVariables}">
@@ -85,6 +106,26 @@
                                                                 <ui:SymbolIcon Symbol="Go" FontSize="20" Margin="0"></ui:SymbolIcon>
                                                             </Button>
                                                             <Button Height="28" Width="28" Grid.Column="2" Command="{Binding Rename}" Padding="0" Margin="4 0 0 0" ToolTip.Tip="Rename">
+                                                                <ui:SymbolIcon Symbol="Rename" FontSize="20" Margin="0"></ui:SymbolIcon>
+                                                            </Button>
+                                                        </Grid>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </StackPanel>
+                                    </StackPanel>
+                                    
+                                    <!-- Options Definition -->
+                                    <StackPanel VerticalAlignment="Top" HorizontalAlignment="Stretch"
+                                                Spacing="10" IsVisible="{Binding HasOptionDefinition}">
+                                        <TextBlock FontSize="18" TextAlignment="Left" HorizontalAlignment="Center" FontWeight="DemiBold" Text="{Binding OptionTitle}"/>
+                                        <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch" Margin="5 8">
+                                            <ItemsControl ItemsSource="{Binding Options}">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <Grid ColumnDefinitions="*,Auto" Margin="0 2">
+                                                            <TextBlock TextAlignment="Left" VerticalAlignment="Center" HorizontalAlignment="Left" Text="{Binding Name}"/>
+                                                            <Button Height="28" Width="28" Grid.Column="2" Command="{Binding Rename}" Padding="0" ToolTip.Tip="Rename">
                                                                 <ui:SymbolIcon Symbol="Rename" FontSize="20" Margin="0"></ui:SymbolIcon>
                                                             </Button>
                                                         </Grid>

--- a/SkEditor/Controls/Sidebar/CodeParser/ParserSidebarPanel.axaml
+++ b/SkEditor/Controls/Sidebar/CodeParser/ParserSidebarPanel.axaml
@@ -38,29 +38,62 @@
                             <Expander CornerRadius="0" Margin="0 5">
                                 <Expander.Header>
                                     <StackPanel Orientation="Horizontal">
-                                        <ui:IconSourceElement Width="18" Height="18" IconSource="{Binding Icon}"></ui:IconSourceElement>
+                                        <ui:IconSourceElement Width="20" Height="20" IconSource="{Binding Icon}"></ui:IconSourceElement>
                                         <TextBlock Text="{Binding Name}" Margin="10 0 0 0" FontWeight="DemiBold"/>
                                     </StackPanel>
                                 </Expander.Header>
                                 <StackPanel Spacing="10">
-                                    <Button HorizontalContentAlignment="Center" HorizontalAlignment="Stretch"
-                                            Content="Navigate to the section" IsEnabled="{Binding Parser.IsParsed}"
-                                            Name="NavigateToButton" Command="{Binding NavigateToCommand}" />
+                                    <Grid ColumnDefinitions="*,*">
+                                        <TextBlock VerticalAlignment="Center" Text="{Binding LinesDisplay}" />
+                                        <Button Grid.Column="1" HorizontalContentAlignment="Center" HorizontalAlignment="Stretch"
+                                                Content="Navigate"
+                                                Name="NavigateToButton" Command="{Binding NavigateToCommand}" />
+                                    </Grid>
                                     <Separator Margin="0 3"/>
-                                    <TextBlock TextAlignment="Left" HorizontalAlignment="Center" FontWeight="DemiBold" Text="{Binding VariableTitle}"/>
-                                    <!-- {Binding VariableContent} -->
-                                    <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch" Margin="5 8">
-                                        <ItemsControl ItemsSource="{Binding UniqueVariables}">
-                                            <ItemsControl.ItemTemplate>
-                                                <DataTemplate>
-                                                    <Grid ColumnDefinitions="*,Auto" Margin="0 2">
-                                                        <TextBlock TextAlignment="Left" FontStyle="{Binding Style}" Text="{Binding Name}"/>
-                                                        <Button IsEnabled="{Binding Section.Parser.IsParsed}" Grid.Column="1" Command="{Binding Rename}" Content="Rename"/>
-                                                    </Grid>
-                                                </DataTemplate>
-                                            </ItemsControl.ItemTemplate>
-                                        </ItemsControl>
+                                    
+                                    <!-- Variables -->
+                                    <StackPanel VerticalAlignment="Top" HorizontalAlignment="Stretch"
+                                                Spacing="10" IsVisible="{Binding HasAnyVariables}">
+                                        <TextBlock FontSize="18" TextAlignment="Left" HorizontalAlignment="Center" FontWeight="DemiBold" Text="{Binding VariableTitle}"/>
+                                        <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch" Margin="5 8">
+                                            <ItemsControl ItemsSource="{Binding UniqueVariables}">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <Grid ColumnDefinitions="*,Auto" Margin="0 2">
+                                                            <TextBlock TextAlignment="Left" FontStyle="{Binding Style}" Text="{Binding Name}"/>
+                                                            <Button Height="28" Width="28" Grid.Column="1" Command="{Binding Rename}" Padding="0" ToolTip.Tip="Rename">
+                                                                <ui:SymbolIcon Symbol="Rename" FontSize="20" Margin="0"></ui:SymbolIcon>
+                                                            </Button>
+                                                        </Grid>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </StackPanel>
                                     </StackPanel>
+                                    
+                                    <!-- Options Reference -->
+                                    <StackPanel VerticalAlignment="Top" HorizontalAlignment="Stretch"
+                                                Spacing="10" IsVisible="{Binding HasAnyOptionReferences}">
+                                        <TextBlock FontSize="18" TextAlignment="Left" HorizontalAlignment="Center" FontWeight="DemiBold" Text="{Binding OptionReferenceTitle}"/>
+                                        <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch" Margin="5 8">
+                                            <ItemsControl ItemsSource="{Binding UniqueOptionReferences}">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <Grid ColumnDefinitions="*,Auto,Auto" Margin="0 2">
+                                                            <TextBlock TextAlignment="Left" VerticalAlignment="Center" HorizontalAlignment="Left" Text="{Binding Name}"/>
+                                                            <Button Height="28" Width="28" Grid.Column="1" Command="{Binding NavigateToDefinition}" Padding="0" ToolTip.Tip="Navigate to definition">
+                                                                <ui:SymbolIcon Symbol="Go" FontSize="20" Margin="0"></ui:SymbolIcon>
+                                                            </Button>
+                                                            <Button Height="28" Width="28" Grid.Column="2" Command="{Binding Rename}" Padding="0" Margin="4 0 0 0" ToolTip.Tip="Rename">
+                                                                <ui:SymbolIcon Symbol="Rename" FontSize="20" Margin="0"></ui:SymbolIcon>
+                                                            </Button>
+                                                        </Grid>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </StackPanel>
+                                    </StackPanel>
+                                    
                                 </StackPanel >
                             </Expander>
                         </DataTemplate>

--- a/SkEditor/Controls/Sidebar/CodeParser/ParserSidebarPanel.axaml
+++ b/SkEditor/Controls/Sidebar/CodeParser/ParserSidebarPanel.axaml
@@ -1,0 +1,78 @@
+﻿<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:ui="using:FluentAvalonia.UI.Controls"
+             xmlns:parser="clr-namespace:SkEditor.Utilities.Parser"
+             x:Class="SkEditor.Controls.Sidebar.ParserSidebarPanel">
+    
+    <UserControl.Styles>
+        <Style Selector="Button.barButton">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Padding" Value="0"/>
+        </Style>
+        <Style Selector="Separator">
+            <Setter Property="Margin" Value="0,1"/>
+        </Style>
+        <Style Selector="TreeViewItem">
+            <Setter Property="FontWeight" Value="Regular"/>
+        </Style>
+    </UserControl.Styles>
+    
+    <Border Name="ExtendedSideBar" Background="{DynamicResource SkEditorBorderBackground}" CornerRadius="7" Margin="10,0,0,0">
+        <Border.Transitions>
+            <Transitions>
+                <DoubleTransition Property="Width" Duration="0:0:0.05" Easing="QuadraticEaseIn"/>
+            </Transitions>
+        </Border.Transitions>
+
+        <Grid RowDefinitions="auto,auto,auto,*,auto">
+            <TextBlock Grid.Row="0" Text="Code Parsing" FontWeight="DemiBold" Margin="20,10,20,10"/>
+            <Separator Grid.Row="1" Margin="0,0,0,10"/>
+            <ui:InfoBar Margin="5 0" Grid.Row="2" IsOpen="True" IsClosable="False" Severity="Warning" Message="The code parser is still in beta! Report any bugs found in the Discord server."/>
+            <ScrollViewer Grid.Row="3" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" VerticalContentAlignment="Top" HorizontalContentAlignment="Center">
+                <ItemsRepeater Name="ItemsRepeater">
+                    <ItemsRepeater.ItemTemplate>
+                        <DataTemplate DataType="parser:CodeSection">
+                            <Expander CornerRadius="0" Margin="0 5">
+                                <Expander.Header>
+                                    <StackPanel Orientation="Horizontal">
+                                        <ui:IconSourceElement Width="18" Height="18" IconSource="{Binding Icon}"></ui:IconSourceElement>
+                                        <TextBlock Text="{Binding Name}" Margin="10 0 0 0" FontWeight="DemiBold"/>
+                                    </StackPanel>
+                                </Expander.Header>
+                                <StackPanel Spacing="10">
+                                    <Button HorizontalContentAlignment="Center" HorizontalAlignment="Stretch"
+                                            Content="Navigate to the section" IsEnabled="{Binding Parser.IsParsed}"
+                                            Name="NavigateToButton" Command="{Binding NavigateToCommand}" />
+                                    <Separator Margin="0 3"/>
+                                    <TextBlock TextAlignment="Left" HorizontalAlignment="Center" FontWeight="DemiBold" Text="{Binding VariableTitle}"/>
+                                    <!-- {Binding VariableContent} -->
+                                    <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch" Margin="5 8">
+                                        <ItemsControl ItemsSource="{Binding UniqueVariables}">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <Grid ColumnDefinitions="*,Auto" Margin="0 2">
+                                                        <TextBlock TextAlignment="Left" FontStyle="{Binding Style}" Text="{Binding Name}"/>
+                                                        <Button IsEnabled="{Binding Section.Parser.IsParsed}" Grid.Column="1" Command="{Binding Rename}" Content="Rename"/>
+                                                    </Grid>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </StackPanel>
+                                </StackPanel >
+                            </Expander>
+                        </DataTemplate>
+                    </ItemsRepeater.ItemTemplate>
+                </ItemsRepeater>
+            </ScrollViewer>
+            <StackPanel Margin="10" Name="CannotParseInfo" Grid.Row="3" VerticalAlignment="Center" HorizontalAlignment="Stretch" IsVisible="False">
+                <TextBlock Name="CannotParseInfoText" TextAlignment="Center" TextWrapping="Wrap"></TextBlock>
+            </StackPanel>
+            <StackPanel Grid.Row="4" HorizontalAlignment="Stretch" Margin="10">
+                <Button Name="ParseButton" Classes="accent" HorizontalAlignment="Center">Parse Code</Button>
+            </StackPanel>
+        </Grid>
+    </Border>
+</UserControl>

--- a/SkEditor/Controls/Sidebar/CodeParser/ParserSidebarPanel.axaml
+++ b/SkEditor/Controls/Sidebar/CodeParser/ParserSidebarPanel.axaml
@@ -20,18 +20,18 @@
         </Style>
     </UserControl.Styles>
     
-    <Border Name="ExtendedSideBar" Background="{DynamicResource SkEditorBorderBackground}" CornerRadius="7" Margin="10,0,0,0">
-        <Border.Transitions>
-            <Transitions>
-                <DoubleTransition Property="Width" Duration="0:0:0.05" Easing="QuadraticEaseIn"/>
-            </Transitions>
-        </Border.Transitions>
+    <Border MinWidth="350" Name="ExtendedSideBar" Background="{DynamicResource SkEditorBorderBackground}" CornerRadius="7" Margin="10,0,0,0">
+        
 
         <Grid RowDefinitions="auto,auto,auto,*,auto">
             <TextBlock Grid.Row="0" Text="Code Parsing" FontWeight="DemiBold" Margin="20,10,20,10"/>
             <Separator Grid.Row="1" Margin="0,0,0,10"/>
             <ui:InfoBar Margin="5 0" Grid.Row="2" IsOpen="True" IsClosable="False" Severity="Warning" Message="The code parser is still in beta! Report any bugs found in the Discord server."/>
-            <ScrollViewer Grid.Row="3" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" VerticalContentAlignment="Top" HorizontalContentAlignment="Center">
+            <StackPanel Margin="10" Name="ParserDisabled" Grid.Row="3" VerticalAlignment="Center" HorizontalAlignment="Stretch" IsVisible="False" Spacing="10">
+                <TextBlock TextAlignment="Center" TextWrapping="Wrap">The code parser is still in beta and bugs may occur. It is disabled by default but you can enable it using the button below.</TextBlock>
+                <Button Name="EnableParser" HorizontalAlignment="Center" VerticalAlignment="Center" Classes="accent">Enable</Button>
+            </StackPanel>
+            <ScrollViewer Name="ScrollViewer" Grid.Row="3" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" VerticalContentAlignment="Top" HorizontalContentAlignment="Center">
                 <ItemsRepeater Name="ItemsRepeater">
                     <ItemsRepeater.ItemTemplate>
                         <DataTemplate DataType="parser:CodeSection">

--- a/SkEditor/Controls/Sidebar/CodeParser/ParserSidebarPanel.axaml.cs
+++ b/SkEditor/Controls/Sidebar/CodeParser/ParserSidebarPanel.axaml.cs
@@ -16,8 +16,7 @@ public partial class ParserSidebarPanel : UserControl
     public void Refresh(List<CodeSection> sections)
     {
         Sections.Clear();
-        foreach (var section in sections)
-            Sections.Add(section);
+        sections.ForEach(section => Sections.Add(section));
         ItemsRepeater.ItemsSource = Sections;
         UpdateInformationBox();
     }
@@ -42,8 +41,16 @@ public partial class ParserSidebarPanel : UserControl
         parser.Parse();
     }
 
-    private void UpdateInformationBox()
+    public void UpdateInformationBox(bool isToNotifyUnParsing = false)
     {
+        if (isToNotifyUnParsing)
+        {
+            Sections.Clear();
+            CannotParseInfo.IsVisible = true;
+            CannotParseInfoText.Text = "File changed, you need to parse it again.";
+            return;
+        }
+        
         if (Sections.Count == 0)
         {
             CannotParseInfo.IsVisible = true;
@@ -70,5 +77,7 @@ public partial class ParserSidebarPanel : UserControl
         public override bool IsDisabled => false;
         
         public readonly ParserSidebarPanel Panel = new ();
+        
+        public override int DesiredWidth { get; } = 350;
     }
 }

--- a/SkEditor/Controls/Sidebar/CodeParser/ParserSidebarPanel.axaml.cs
+++ b/SkEditor/Controls/Sidebar/CodeParser/ParserSidebarPanel.axaml.cs
@@ -1,0 +1,74 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Avalonia.Controls;
+using FluentAvalonia.UI.Controls;
+using SkEditor.API;
+using SkEditor.Utilities;
+using SkEditor.Utilities.Files;
+using SkEditor.Utilities.Parser;
+
+namespace SkEditor.Controls.Sidebar;
+
+public partial class ParserSidebarPanel : UserControl
+{
+    public ObservableCollection<CodeSection> Sections { get; set; } = new ();
+    
+    public void Refresh(List<CodeSection> sections)
+    {
+        Sections.Clear();
+        foreach (var section in sections)
+            Sections.Add(section);
+        ItemsRepeater.ItemsSource = Sections;
+        UpdateInformationBox();
+    }
+    
+    public ParserSidebarPanel()
+    {
+        InitializeComponent();
+        
+        ParseButton.Click += (_, _) => ParseCurrentFile();
+    }
+
+    public void ParseCurrentFile()
+    {
+        var selectedItem = ApiVault.Get().GetTabView().SelectedItem as TabViewItem;
+        if (selectedItem == null) 
+            return;
+        var parser = FileHandler.OpenedFiles.Find(file => file.TabViewItem == selectedItem)?.Parser;
+        if (parser == null) 
+            return;
+            
+        ParseButton.IsEnabled = false;
+        parser.Parse();
+    }
+
+    private void UpdateInformationBox()
+    {
+        if (Sections.Count == 0)
+        {
+            CannotParseInfo.IsVisible = true;
+            CannotParseInfoText.Text = "No sections found in the code. Maybe you should write something? :)";
+            return;
+        }
+
+        var parser = Sections[0].Parser;
+        if (!parser.IsValid())
+        {
+            Sections.Clear();
+            CannotParseInfo.IsVisible = true;
+            CannotParseInfoText.Text = "This file cannot be parsed, as it do not look likes a script file.";
+            return;
+        }
+
+        CannotParseInfo.IsVisible = false;
+    }
+    
+    public class ParserPanel : SidebarPanel
+    {
+        public override UserControl Content => Panel;
+        public override IconSource Icon => new SymbolIconSource() { Symbol = Symbol.Code };
+        public override bool IsDisabled => false;
+        
+        public readonly ParserSidebarPanel Panel = new ();
+    }
+}

--- a/SkEditor/Languages/English.xaml
+++ b/SkEditor/Languages/English.xaml
@@ -93,6 +93,7 @@
 	<system:String x:Key="RefactorWindowRemoveComments">Remove comments</system:String>
 	<system:String x:Key="RefactorWindowTabsToSpaces">Convert tabs to spaces</system:String>
 	<system:String x:Key="RefactorWindowSpacesToTabs">Convert spaces to tabs</system:String>
+	<system:String x:Key="RefactorWindowRefactorBoxName">Renaming '{0}' into ...</system:String>
 
 	<!-- Settings -->
 	<system:String x:Key="SettingsEnabled">Enabled</system:String>

--- a/SkEditor/SkEditor.cs
+++ b/SkEditor/SkEditor.cs
@@ -14,6 +14,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using SkEditor.Utilities.Files;
 
 namespace SkEditor;
 
@@ -66,6 +67,11 @@ public class SkEditor : ISkEditorAPI
     public TextEditor GetTextEditor()
     {
         return GetMainWindow().TabControl.SelectedItem is TabViewItem tabItem && IsFile(tabItem) ? tabItem.Content as TextEditor : null;
+    }
+    
+    public OpenedFile? GetOpenedFile()
+    {
+        return FileHandler.OpenedFiles.FirstOrDefault(file => file.TabViewItem == GetMainWindow().TabControl.SelectedItem);
     }
 
     /// <returns>App's tabcontrol</returns>

--- a/SkEditor/Utilities/AppConfig.cs
+++ b/SkEditor/Utilities/AppConfig.cs
@@ -40,6 +40,7 @@ public class AppConfig
     public int TabSize { get; set; } = 4;
     public bool EnableProjectsExperiment { get; set; } = false;
     public bool EnableHexPreview { get; set; } = false;
+    public bool EnableCodeParser { get; set; } = false;
 
 
     public static string AppDataFolderPath { get; set; } = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "SkEditor");

--- a/SkEditor/Utilities/Editor/CustomCommandsHandler.cs
+++ b/SkEditor/Utilities/Editor/CustomCommandsHandler.cs
@@ -4,6 +4,9 @@ using AvaloniaEdit.Editing;
 using SkEditor.API;
 using System;
 using System.Linq;
+using SkEditor.Utilities.Files;
+using SkEditor.Utilities.Parser;
+using SkEditor.Views;
 
 namespace SkEditor.Utilities.Editor;
 public class CustomCommandsHandler
@@ -68,5 +71,26 @@ public class CustomCommandsHandler
         int newCaretOffset = usedOffset + Environment.NewLine.Length + selectedText.Length;
         textArea.Caret.Offset = newCaretOffset;
         textArea.Caret.BringCaretToView();
+    }
+    
+    public static async void OnRefactorCommandExecuted(TextEditor editor)
+    {
+        var parser = FileHandler.OpenedFiles.Find(file => file.Editor == editor).Parser;
+        if (parser == null)
+            return;
+        if (!parser.IsParsed)
+            parser.Parse();
+        
+        var section = parser.GetSectionFromLine(editor.TextArea.Caret.Line);
+        if (section == null)
+            return;
+        
+        var variable = section.GetVariableFromCaret(editor.TextArea.Caret);
+        var option = section.GetOptionFromCaret(editor.TextArea.Caret);
+        if (variable == null && option == null)
+            return;
+        
+        var renameWindow = new SymbolRefactorWindow((INameableCodeElement) variable ?? option);
+        await renameWindow.ShowDialog(ApiVault.Get().GetMainWindow());
     }
 }

--- a/SkEditor/Utilities/Files/FileBuilder.cs
+++ b/SkEditor/Utilities/Files/FileBuilder.cs
@@ -100,6 +100,7 @@ public class FileBuilder
         editor.TextChanged += TextEditorEventHandler.OnTextChanged;
         editor.TextArea.TextEntered += TextEditorEventHandler.DoAutoIndent;
         editor.TextArea.TextEntered += TextEditorEventHandler.DoAutoPairing;
+        editor.TextChanged += (sender, args) => ApiVault.Get().GetOpenedFile().Parser.IsParsed = false;
         editor.Document.TextChanged += TextEditorEventHandler.CheckForHex;
         editor.TextArea.Caret.PositionChanged += (sender, e) =>
         {
@@ -123,6 +124,7 @@ public class FileBuilder
         editor.TextArea.TextView.LinkTextForegroundBrush = new ImmutableSolidColorBrush(Color.Parse("#1a94c4"));
         editor.TextArea.TextView.LinkTextUnderline = true;
         editor.TextArea.SelectionBrush = (ImmutableSolidColorBrush)Application.Current.FindResource("SelectionColor");
+        editor.TextArea.RightClickMovesCaret = true;
 
         editor.TextArea.LeftMargins.OfType<LineNumberMargin>().FirstOrDefault().Margin = new Thickness(10, 0);
 
@@ -143,7 +145,8 @@ public class FileBuilder
             new { Header = "MenuHeaderRedo", Command = new RelayCommand(() => editor.Redo()), Icon = Symbol.Redo },
             new { Header = "MenuHeaderDuplicate", Command = new RelayCommand(() => CustomCommandsHandler.OnDuplicateCommandExecuted(editor.TextArea)), Icon = Symbol.Copy },
             new { Header = "MenuHeaderComment", Command = new RelayCommand(() => CustomCommandsHandler.OnCommentCommandExecuted(editor.TextArea)), Icon = Symbol.Comment },
-            new { Header = "MenuHeaderDelete", Command = new RelayCommand(editor.Delete), Icon = Symbol.Delete }
+            new { Header = "MenuHeaderDelete", Command = new RelayCommand(editor.Delete), Icon = Symbol.Delete },
+            new { Header = "MenuHeaderRefactor", Command = new RelayCommand(() => CustomCommandsHandler.OnRefactorCommandExecuted(editor)), Icon = Symbol.Rename },
         };
 
         var contextMenu = new MenuFlyout();

--- a/SkEditor/Utilities/Files/FileBuilder.cs
+++ b/SkEditor/Utilities/Files/FileBuilder.cs
@@ -100,7 +100,7 @@ public class FileBuilder
         editor.TextChanged += TextEditorEventHandler.OnTextChanged;
         editor.TextArea.TextEntered += TextEditorEventHandler.DoAutoIndent;
         editor.TextArea.TextEntered += TextEditorEventHandler.DoAutoPairing;
-        editor.TextChanged += (sender, args) => ApiVault.Get().GetOpenedFile().Parser.IsParsed = false;
+        editor.TextChanged += (_, _) => ApiVault.Get().GetOpenedFile()?.Parser?.SetUnparsed();
         if (ApiVault.Get().GetAppConfig().EnableHexPreview)
         {
             editor.Document.TextChanged += (_, _) => TextEditorEventHandler.CheckForHex(editor);

--- a/SkEditor/Utilities/Files/FileHandler.cs
+++ b/SkEditor/Utilities/Files/FileHandler.cs
@@ -44,6 +44,16 @@ public class FileHandler
     {
         string header = Translation.Get("NewFileNameFormat").Replace("{0}", GetUntitledNumber().ToString());
         TabViewItem tabItem = await FileBuilder.Build(header);
+        OpenedFiles.Add(new OpenedFile()
+        {
+            Editor = tabItem.Content as TextEditor,
+            Path = "",
+            TabViewItem = tabItem,
+            Parser = tabItem.Content is TextEditor editor 
+                ? new CodeParser(editor)
+                : null
+        });
+        
         (ApiVault.Get().GetTabView().TabItems as IList)?.Add(tabItem);
     }
 

--- a/SkEditor/Utilities/Files/OpenedFile.cs
+++ b/SkEditor/Utilities/Files/OpenedFile.cs
@@ -1,0 +1,16 @@
+﻿using Avalonia.Media;
+using AvaloniaEdit;
+using FluentAvalonia.UI.Controls;
+using SkEditor.Utilities.Parser;
+
+namespace SkEditor.Utilities.Files;
+
+public class OpenedFile
+{
+    
+    public TextEditor? Editor { get; set; }
+    public string Path { get; set; }
+    public TabViewItem TabViewItem { get; set; }
+    public CodeParser? Parser { get; set; }
+    
+}

--- a/SkEditor/Utilities/Parser/CodeParser.cs
+++ b/SkEditor/Utilities/Parser/CodeParser.cs
@@ -27,8 +27,6 @@ public class CodeParser : INotifyPropertyChanged
     /// </summary>
     public TextEditor Editor { get; private set; }
     
-    private bool _isParsed = false;
-    
     /// <summary>
     /// Get the parsed code sections. This will be empty if the code is not parsed yet.
     /// </summary>
@@ -45,8 +43,10 @@ public class CodeParser : INotifyPropertyChanged
     /// Get the options section, if any is defined.
     /// </summary>
     /// <returns></returns>
-    public CodeSection GetOptionsSection() => Sections.Find(section => section.Type == CodeSection.SectionType.Options);
-    
+    public CodeSection? GetOptionsSection() => Sections.Find(section => section.Type == CodeSection.SectionType.Options);
+
+    public bool IsParsed { get; private set; } = false;
+
     /// <summary>
     /// Get section from a line.
     /// </summary>
@@ -56,8 +56,14 @@ public class CodeParser : INotifyPropertyChanged
 
     public void Parse()
     {
-        IsParsed = true;
         Sections.Clear();
+        if (!IsValid())
+        {
+            SetUnparsed();
+            return;
+        }
+
+        IsParsed = true;
         
         // Split the code into lines
         List<string> lines = Editor.Text.Split('\n').ToList();
@@ -103,21 +109,12 @@ public class CodeParser : INotifyPropertyChanged
         IsParsed = false;
         ParserPanel.ParseButton.IsEnabled = true;
         ParserPanel.ParseButton.Content = "Parse code";
+        ParserPanel.UpdateInformationBox(true);
     }
 
     public bool IsValid()
     {
-        return !Editor.Text.ToList().Any(c => char.IsControl(c) && c != '\n' && c != '\r' && c != '\t'); 
-    }
-    
-    public bool IsParsed
-    {
-        get => _isParsed;
-        set
-        {
-            _isParsed = value;
-            OnPropertyChanged(nameof(_isParsed));
-        }
+        return !Editor.Text.Any(c => char.IsControl(c) && c != '\n' && c != '\r' && c != '\t'); 
     }
     
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/SkEditor/Utilities/Parser/CodeParser.cs
+++ b/SkEditor/Utilities/Parser/CodeParser.cs
@@ -81,13 +81,15 @@ public class CodeParser
                     lastSectionLine = lineIndex;
                 }
             }
-            
-            if (lineIndex == lines.Count - 1) // Ending
-            {
-                var linesToParse = lines.GetRange(lastSectionLine, lineIndex - lastSectionLine + 1);
-                Sections.Add(new CodeSection(this, lastSectionLine, linesToParse));
-            }
-            
         }
+        
+        // Parse the last section
+        if (lastSectionLine != -1)
+        {
+            var linesToParse = lines.GetRange(lastSectionLine, lines.Count - lastSectionLine);
+            Sections.Add(new CodeSection(this, lastSectionLine, linesToParse));
+        }
+
+        ApiVault.Get().Log($"Parsed a total of {Sections.Count} sections.", true);
     }
 }

--- a/SkEditor/Utilities/Parser/CodeParser.cs
+++ b/SkEditor/Utilities/Parser/CodeParser.cs
@@ -1,0 +1,93 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using AvaloniaEdit;
+using SkEditor.API;
+
+namespace SkEditor.Utilities.Parser;
+
+public class CodeParser
+{
+    
+    public CodeParser(TextEditor textEditor, bool parse = true)
+    {
+        Editor = textEditor;
+        Sections = new List<CodeSection>();
+        if (parse) 
+            Parse();
+    }
+    
+    /// <summary>
+    /// Get the editor that is being parsed.
+    /// </summary>
+    public TextEditor Editor { get; private set; }
+    
+    /// <summary>
+    /// Check if the code is parsed yet.
+    /// </summary>
+    public bool IsParsed { get; set; }
+    
+    /// <summary>
+    /// Get the parsed code sections. This will be empty if the code is not parsed yet.
+    /// </summary>
+    public List<CodeSection> Sections { get; private set; }
+    
+    /// <summary>
+    /// Get sections with the specified type.
+    /// </summary>
+    /// <param name="sectionType"></param>
+    /// <returns></returns>
+    public List<CodeSection> GetSectionFromType(CodeSection.SectionType sectionType) => Sections.FindAll(section => section.Type == sectionType);
+    
+    /// <summary>
+    /// Get the options section, if any is defined.
+    /// </summary>
+    /// <returns></returns>
+    public CodeSection GetOptionsSection() => Sections.Find(section => section.Type == CodeSection.SectionType.Options);
+    
+    /// <summary>
+    /// Get section from a line.
+    /// </summary>
+    /// <param name="line"></param>
+    /// <returns></returns>
+    public CodeSection? GetSectionFromLine(int line) => Sections.Find(section => section.ContainsLineIndex(line));
+
+    public void Parse()
+    {
+        IsParsed = true;
+        Sections.Clear();
+        
+        // Split the code into lines
+        List<string> lines = Editor.Text.Split('\n').ToList();
+        int lastSectionLine = -1;
+
+        // Parse sections
+        for (var lineIndex = 0; lineIndex < lines.Count; lineIndex++)
+        {
+            var line = lines[lineIndex];
+            if (line.Trim().Length == 0)
+                continue;
+
+            if (Regex.IsMatch(line, @"(.*):") && !line.StartsWith(" ") && !line.StartsWith("\t") && !line.StartsWith("#"))
+            {
+                if (lastSectionLine == -1) // Starting
+                {
+                    lastSectionLine = lineIndex;
+                }
+                else
+                {
+                    var linesToParse = lines.GetRange(lastSectionLine, lineIndex - lastSectionLine);
+                    Sections.Add(new CodeSection(this, lastSectionLine, linesToParse));
+                    lastSectionLine = lineIndex;
+                }
+            }
+            
+            if (lineIndex == lines.Count - 1) // Ending
+            {
+                var linesToParse = lines.GetRange(lastSectionLine, lineIndex - lastSectionLine + 1);
+                Sections.Add(new CodeSection(this, lastSectionLine, linesToParse));
+            }
+            
+        }
+    }
+}

--- a/SkEditor/Utilities/Parser/CodeParser.cs
+++ b/SkEditor/Utilities/Parser/CodeParser.cs
@@ -1,13 +1,18 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text.RegularExpressions;
 using AvaloniaEdit;
 using SkEditor.API;
+using SkEditor.Controls.Sidebar;
 
 namespace SkEditor.Utilities.Parser;
 
-public class CodeParser
+public class CodeParser : INotifyPropertyChanged
 {
+
+    public static ParserSidebarPanel ParserPanel =>
+        ApiVault.Get().GetMainWindow().SideBar.ParserPanel.Panel;
     
     public CodeParser(TextEditor textEditor, bool parse = true)
     {
@@ -22,10 +27,7 @@ public class CodeParser
     /// </summary>
     public TextEditor Editor { get; private set; }
     
-    /// <summary>
-    /// Check if the code is parsed yet.
-    /// </summary>
-    public bool IsParsed { get; set; }
+    private bool _isParsed = false;
     
     /// <summary>
     /// Get the parsed code sections. This will be empty if the code is not parsed yet.
@@ -90,6 +92,38 @@ public class CodeParser
             Sections.Add(new CodeSection(this, lastSectionLine, linesToParse));
         }
 
-        ApiVault.Get().Log($"Parsed a total of {Sections.Count} sections.", true);
+        ParserPanel.Refresh(Sections);
+        
+        ParserPanel.ParseButton.IsEnabled = false;
+        ParserPanel.ParseButton.Content = "Current code parsed";
+    }
+
+    public void SetUnparsed()
+    {
+        IsParsed = false;
+        ParserPanel.ParseButton.IsEnabled = true;
+        ParserPanel.ParseButton.Content = "Parse code";
+    }
+
+    public bool IsValid()
+    {
+        return !Editor.Text.ToList().Any(c => char.IsControl(c) && c != '\n' && c != '\r' && c != '\t'); 
+    }
+    
+    public bool IsParsed
+    {
+        get => _isParsed;
+        set
+        {
+            _isParsed = value;
+            OnPropertyChanged(nameof(_isParsed));
+        }
+    }
+    
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
 }

--- a/SkEditor/Utilities/Parser/CodeSection.cs
+++ b/SkEditor/Utilities/Parser/CodeSection.cs
@@ -128,9 +128,9 @@ public class CodeSection
         var editor = Parser.Editor;
         var document = editor.Document;
         var startOffset = document.GetOffset(StartingLineIndex+1, 0);
-        var endOffset = document.GetOffset(
-            document.Lines.Count > EndingLineIndex+1 ? EndingLineIndex+1 : EndingLineIndex, 0
-        );
-        document.Replace(startOffset, endOffset - startOffset, sectionCode + "\n");
+        var endOffset = document.GetOffset(EndingLineIndex, 0);
+        if (EndingLineIndex == document.LineCount)
+            endOffset = document.TextLength;
+        document.Replace(startOffset, endOffset - startOffset, sectionCode);
     }
 }

--- a/SkEditor/Utilities/Parser/CodeSection.cs
+++ b/SkEditor/Utilities/Parser/CodeSection.cs
@@ -1,0 +1,136 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using AvaloniaEdit.Editing;
+using SkEditor.API;
+
+namespace SkEditor.Utilities.Parser;
+
+public class CodeSection
+{
+    public CodeParser Parser { get; private set; }
+    public SectionType Type { get; private set; }
+    public List<string> Lines { get; set; }
+    public int StartingLineIndex { get; private set; }
+    public int EndingLineIndex => StartingLineIndex + Lines.Count;
+    
+    public HashSet<CodeVariable> GetGlobalVariables() => [..Variables.Where(variable => !variable.IsLocal)];
+    public HashSet<CodeVariable> Variables { get; private set; } // Case of any section other than options
+    
+    public HashSet<CodeOption> Options { get; private set; } // Case of options section
+    
+    public bool ContainsLineIndex(int line) => line >= StartingLineIndex && line <= EndingLineIndex;
+    
+    public CodeVariable? GetVariableFromCaret(Caret caret)
+    {
+        foreach (var variable in Variables)
+        {
+            if (variable.ContainsCaret(caret))
+                return variable;
+        }
+        return null;
+    }
+    
+    public CodeOption? GetOptionFromCaret(Caret caret)
+    {
+        foreach (var option in Options)
+        {
+            if (option.ContainsCaret(caret))
+                return option;
+        }
+        return null;
+    }
+
+    public CodeSection(CodeParser parser, int currentLineIndex, List<string> lines)
+    {
+        Parser = parser;
+        Lines = lines;
+        StartingLineIndex = currentLineIndex;
+        Parse();
+    }
+
+    public void Parse()
+    {
+        // Parse section type
+        var firstLine = Lines[0];
+        if (firstLine.StartsWith("command") || firstLine.StartsWith("discord command")) 
+            Type = SectionType.Command;
+        else if (firstLine.Equals("options:"))
+            Type = SectionType.Options;
+        else if (firstLine.StartsWith("function"))
+            Type = SectionType.Function;
+        else 
+            Type = SectionType.Event;
+
+        
+        
+        Options = new HashSet<CodeOption>();
+        Variables = new HashSet<CodeVariable>();
+        
+        if (Type == SectionType.Options)
+        {
+            // Parse options
+            for (var index = 1; index <= Lines.Count; index++)
+            {
+                var line = Lines[index - 1];
+                if (line.TrimStart(' ', '\t').StartsWith('#'))
+                    continue;
+
+                var matches = Regex.Matches(line, @"(.*): (.*)");
+                foreach (var m in matches)
+                {
+                    var match = m as Match;
+                    if (!match.Success)
+                        continue;
+                    var column = match.Index + 1;
+                    var raw = match.Value;
+                    Options.Add(new CodeOption(this, raw, StartingLineIndex + index, column));
+                }
+            }
+        }
+        else
+        {
+            // Parse variables
+            int lineIndex = StartingLineIndex;
+            foreach (var line in Lines)
+            {
+                var matches = Regex.Matches(line, @"(?<=\{)_?(.*?)(?=\})");
+                foreach (var m in matches)
+                {
+                    var match = m as Match;
+                    if (!match.Success)
+                        continue;
+                    var column = match.Index + 1;
+                    var raw = match.Value;
+                    Variables.Add(new CodeVariable(this, raw, lineIndex + 1, column));
+                }
+                lineIndex++;
+            }   
+        }
+    }
+
+    public enum SectionType
+    {
+        Command,
+        Event,
+        Options,
+        Function
+    }
+
+    /// <summary>
+    /// Refresh the editor's content with the new code from this section.
+    /// This will replace the previous code that were in the lines of this section.
+    /// remove the old code.
+    /// </summary>
+    public void RefreshCode()
+    {
+        var sectionCode = string.Join("\n", Lines);
+        var editor = Parser.Editor;
+        var document = editor.Document;
+        var startOffset = document.GetOffset(StartingLineIndex+1, 0);
+        var endOffset = document.GetOffset(
+            document.Lines.Count > EndingLineIndex+1 ? EndingLineIndex+1 : EndingLineIndex, 0
+        );
+        document.Replace(startOffset, endOffset - startOffset, sectionCode + "\n");
+    }
+}

--- a/SkEditor/Utilities/Parser/Elements/CodeFunctionArgument.cs
+++ b/SkEditor/Utilities/Parser/Elements/CodeFunctionArgument.cs
@@ -1,0 +1,62 @@
+﻿using System.Text.RegularExpressions;
+using SkEditor.API;
+using SkEditor.Views;
+
+namespace SkEditor.Utilities.Parser;
+
+/// <summary>
+/// Represent a function argument in a function declaration.
+/// </summary>
+public class CodeFunctionArgument : INameableCodeElement
+{
+    public static readonly string FunctionArgumentPattern = "([a-zA-Z0-9_]+):( )?([a-zA-Z0-9_]+)";
+    
+    public string Name { get; }
+    public string Type { get; }
+    public CodeSection Function { get; }
+    public int Line { get; set; }
+    public int Column { get; set; }
+    public int Length { get; set; }
+    
+    public CodeFunctionArgument(CodeSection function, string raw, int line = -1, int column = -1)
+    {
+        var match = Regex.Match(raw, FunctionArgumentPattern);
+        Name = match.Groups[1].Value;
+        Type = match.Groups[3].Value;
+
+        Function = function;
+        Line = line;
+        Column = column;
+        Length = raw.Length;
+    }
+    
+    public async void Rename()
+    {
+        var renameWindow = new SymbolRefactorWindow(this);
+        await renameWindow.ShowDialog(ApiVault.Get().GetMainWindow());
+        Function.Parser.Parse();
+    }
+    
+    public void Rename(string newName)
+    {
+        // First, rename the function argument in the function declaration
+        var functionDeclaration = Function.Lines[0];
+        var newFunctionDeclaration = functionDeclaration.Replace(Name, newName);
+        Function.Lines[0] = newFunctionDeclaration;
+        
+        // Then replace all local variable with the new name
+        foreach (CodeVariable variable in Function.Variables)
+        {
+            if (variable.IsLocal && variable.Name == Name)
+                variable.Rename(newName, true);
+        }
+        
+        Function.RefreshCode();
+        Function.Parse();
+    }
+
+    public bool IsDefinitionOf(CodeVariable variable)
+    {
+        return variable.Name == Name && variable.IsLocal;
+    }
+}

--- a/SkEditor/Utilities/Parser/Elements/CodeOption.cs
+++ b/SkEditor/Utilities/Parser/Elements/CodeOption.cs
@@ -1,0 +1,55 @@
+﻿using System.Text.RegularExpressions;
+using AvaloniaEdit.Editing;
+using SkEditor.API;
+
+namespace SkEditor.Utilities.Parser;
+
+public class CodeOption : INameableCodeElement
+{
+    public string Name { get; }
+    public CodeSection Section { get; }
+    
+    public int Line { get; set; }
+    public int Column { get; set; }
+    public int Length { get; set; }
+
+    public CodeOption(CodeSection section, string line,
+        int lineIndex = -1, int column = -1)
+    {
+        Section = section;
+        // don't forget to remove the starting tab/spaces
+        Name = line.TrimStart(' ', '\t').Split(':')[0];
+        Line = lineIndex;
+        Column = column;
+        Length = Name.Length;
+    }
+    
+    public bool ContainsCaret(Caret caret)
+    {
+        return caret.Line == Line && caret.Column - 1 >= Column && caret.Column - 1 <= Column + Length;
+    }
+    
+    public void Rename(string newName)
+    {
+        // First rename the option declaration
+        var line = Section.Lines[Line - Section.StartingLineIndex - 1];
+        var regex = new Regex(Regex.Escape(Name));
+        var newLine = regex.Replace(line, newName, 1);
+        Section.Lines[Line - Section.StartingLineIndex -1] = newLine;
+        Length = newName.Length;
+        Section.RefreshCode();
+        
+        // Then rename the option usage everywhere (form is '{@optionName}')
+        var regex2 = new Regex($"{{@{Regex.Escape(Name)}}}");
+        foreach (var section in Section.Parser.Sections)
+        {
+            for (var index = section.StartingLineIndex; index < section.StartingLineIndex + section.Lines.Count; index++)
+            {
+                var line2 = section.Lines[index - section.StartingLineIndex];
+                var newLine2 = regex2.Replace(line2, $"{{@{newName}}}");
+                section.Lines[index - section.StartingLineIndex] = newLine2;
+                section.RefreshCode();
+            }
+        }
+    }
+}

--- a/SkEditor/Utilities/Parser/Elements/CodeOption.cs
+++ b/SkEditor/Utilities/Parser/Elements/CodeOption.cs
@@ -2,6 +2,7 @@
 using System.Text.RegularExpressions;
 using AvaloniaEdit.Editing;
 using SkEditor.API;
+using SkEditor.Views;
 
 namespace SkEditor.Utilities.Parser;
 
@@ -28,6 +29,13 @@ public class CodeOption : INameableCodeElement
     public bool ContainsCaret(Caret caret)
     {
         return caret.Line == Line && caret.Column - 1 >= Column && caret.Column - 1 <= Column + Length;
+    }
+
+    public async void Rename()
+    {
+        var renameWindow = new SymbolRefactorWindow(this);
+        await renameWindow.ShowDialog(ApiVault.Get().GetMainWindow());
+        Section.Parser.Parse();
     }
     
     public void Rename(string newName)

--- a/SkEditor/Utilities/Parser/Elements/CodeOptionReference.cs
+++ b/SkEditor/Utilities/Parser/Elements/CodeOptionReference.cs
@@ -1,0 +1,83 @@
+﻿using System.Linq;
+using System.Text.RegularExpressions;
+using SkEditor.API;
+using SkEditor.Views;
+
+namespace SkEditor.Utilities.Parser;
+
+/// <summary>
+/// This represent an option reference, e.g. '{@optionName}' and not its declaration, that is <see cref="CodeOption"/>.
+/// </summary>
+public class CodeOptionReference : INameableCodeElement
+{
+    public static readonly string OptionReferencePattern = @"{@([a-zA-Z0-9_]+)}";
+    
+    public CodeSection Section { get; private set; }
+    
+    public string Name { get; private set; }
+    
+    public int Line { get; set; }
+    public int Column { get; set; }
+    public int Length { get; set; }
+    
+    public CodeOptionReference(CodeSection section, string raw, 
+        int line = -1, int column = -1)
+    {
+        var match = Regex.Match(raw, OptionReferencePattern);
+        Section = section;
+        Name = match.Groups[1].Value;
+        Line = line;
+        Column = column;
+        Length = raw.Length;
+    }
+    
+    public override string ToString()
+    {
+        return $"{{@{Name}}}";
+    }
+    
+    public bool IsSimilar(CodeOptionReference other)
+    {
+        return Name == other.Name;
+    }
+    
+    public bool IsSimilar(CodeOption definition)
+    {
+        return Name == definition.Name;
+    }
+    
+    public void Rename(string newName)
+    {
+        Section.Parser.GetOptionsSection()?.Options.ToList().Find(o => o.Name == Name)?.Rename(newName);
+    }
+    
+    public async void Rename()
+    {
+        var renameWindow = new SymbolRefactorWindow(this);
+        await renameWindow.ShowDialog(ApiVault.Get().GetMainWindow());
+        Section.Parser.Parse();
+    }
+    
+    public void Replace(string newName)
+    {
+        if (newName.StartsWith("{") && newName.EndsWith("}")) 
+            newName = newName[1..^1];
+        
+        Section.Lines[Line - Section.StartingLineIndex - 1] = Section.Lines[Line - Section.StartingLineIndex - 1].Replace(ToString(), 
+            $"{{@{newName}}}");
+        Section.RefreshCode();
+    }
+
+    public void NavigateToDefinition()
+    {
+        var optionsSection = Section.Parser.GetOptionsSection();
+        var option = optionsSection?.Options.ToList().Find(o => o.Name == Name);
+        if (option != null)
+        {
+            var editor = Section.Parser.Editor;
+            editor.ScrollTo(option.Line, option.Column);
+            editor.CaretOffset = editor.Document.GetOffset(option.Line, option.Column);
+            editor.Focus();
+        }
+    }
+}

--- a/SkEditor/Utilities/Parser/Elements/CodeVariable.cs
+++ b/SkEditor/Utilities/Parser/Elements/CodeVariable.cs
@@ -74,6 +74,36 @@ public class CodeVariable : INameableCodeElement
             Section.Lines = newLines;
             Section.RefreshCode();
             Section.Parse();
+        } 
+        else // rename all within the file
+        {
+            foreach (var section in Section.Parser.Sections)
+            {
+                var current = section.Lines;
+                var newLines = new List<string>();
+                foreach (var line in current)
+                {
+                    bool lineAdded = false;
+                    var matches = Regex.Matches(line, @"(?<=\{)_?(.*?)(?=\})");
+                    foreach (var m in matches)
+                    {
+                        var variable = new CodeVariable(Section, m.ToString(), Line, Column);
+                        if (variable.IsSimilar(this))
+                        {
+                            var newLine = line.Replace(variable.ToString(), $"{{{newName}}}");
+                            newLines.Add(newLine);
+                            lineAdded = true;
+                        }
+                    }
+                
+                    if (!lineAdded) 
+                        newLines.Add(line);
+                }
+
+                section.Lines = newLines;
+                section.RefreshCode();
+                section.Parse();
+            }
         }
     }
 

--- a/SkEditor/Utilities/Parser/Elements/CodeVariable.cs
+++ b/SkEditor/Utilities/Parser/Elements/CodeVariable.cs
@@ -1,0 +1,84 @@
+﻿using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using AvaloniaEdit.Editing;
+using SkEditor.API;
+
+namespace SkEditor.Utilities.Parser;
+
+public class CodeVariable : INameableCodeElement
+{
+    public CodeSection Section { get; private set; }
+    
+    public string Name { get; private set; }
+
+    public bool IsLocal { get; private set; }
+    
+    public int Line { get; set; }
+    public int Column { get; set; }
+    public int Length { get; set; }
+    
+    public CodeVariable(CodeSection section, string raw, 
+        int line = -1, int column = -1)
+    {
+        Section = section;
+        IsLocal = raw.StartsWith("_");
+        Name = raw.TrimStart('_');
+        Line = line;
+        Column = column;
+        Length = raw.Length;
+    }
+
+    public override string ToString()
+    {
+        return $"{{{(IsLocal ? "_" : "")}{Name}}}";
+    }
+    
+    public bool IsSimilar(CodeVariable other)
+    {
+        return Name == other.Name && IsLocal == other.IsLocal;
+    }
+
+    public bool ContainsCaret(Caret caret)
+    {
+        return caret.Line == Line && caret.Column - 1 >= Column && caret.Column - 1 <= Column + Length;
+    }
+    
+    public void Rename(string newName)
+    {
+        if (newName.StartsWith("{") && newName.EndsWith("}")) newName = newName[1..^1];
+        if (newName.StartsWith("_")) newName = newName[1..];
+        
+        if (IsLocal) // rename all within the section
+        {
+            var current = Section.Lines;
+            var newLines = new List<string>();
+            foreach (var line in current)
+            {
+                bool lineAdded = false;
+                var matches = Regex.Matches(line, @"(?<=\{)_?(.*?)(?=\})");
+                foreach (var m in matches)
+                {
+                    var variable = new CodeVariable(Section, m.ToString(), Line, Column);
+                    if (variable.IsSimilar(this))
+                    {
+                        var newLine = line.Replace(variable.ToString(), $"{{_{newName}}}");
+                        newLines.Add(newLine);
+                        lineAdded = true;
+                    }
+                }
+                
+                if (!lineAdded) 
+                    newLines.Add(line);
+            }
+
+            Section.Lines = newLines;
+            Section.RefreshCode();
+            Section.Parse();
+        }
+    }
+
+    public string GetNameDisplay()
+    {
+        return $"{{{(IsLocal ? "_" : "")}{Name}}}";
+    }
+}

--- a/SkEditor/Utilities/Parser/Elements/CodeVariable.cs
+++ b/SkEditor/Utilities/Parser/Elements/CodeVariable.cs
@@ -31,6 +31,16 @@ public class CodeVariable : ObservableObject, INameableCodeElement
         Column = column;
         Length = raw.Length;
     }
+    
+    public CodeVariable(CodeFunctionArgument argument)
+    {
+        Section = argument.Function;
+        IsLocal = true;
+        Name = argument.Name;
+        Line = argument.Line;
+        Column = argument.Column;
+        Length = argument.Length;
+    }
 
     public override string ToString()
     {
@@ -48,11 +58,23 @@ public class CodeVariable : ObservableObject, INameableCodeElement
     }
     
     public FontStyle Style => IsLocal ? FontStyle.Italic : FontStyle.Normal;
-    
+
     public void Rename(string newName)
+    {
+        Rename(newName, false);
+    }
+
+    public void Rename(string newName, bool callingFromFunction = false)
     {
         if (newName.StartsWith("{") && newName.EndsWith("}")) newName = newName[1..^1];
         if (newName.StartsWith("_")) newName = newName[1..];
+
+        var definition = Section.GetVariableDefinition(this);
+        if (definition != null && !callingFromFunction)
+        {
+            definition.Rename(newName);
+            return;
+        }
         
         if (IsLocal) // rename all within the section
         {

--- a/SkEditor/Utilities/Parser/Elements/CodeVariable.cs
+++ b/SkEditor/Utilities/Parser/Elements/CodeVariable.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using Avalonia.Media;
 using AvaloniaEdit.Editing;
 using SkEditor.API;
+using SkEditor.Views;
 
 namespace SkEditor.Utilities.Parser;
 
@@ -41,6 +43,14 @@ public class CodeVariable : INameableCodeElement
     public bool ContainsCaret(Caret caret)
     {
         return caret.Line == Line && caret.Column - 1 >= Column && caret.Column - 1 <= Column + Length;
+    }
+    
+    public FontStyle Style => IsLocal ? FontStyle.Italic : FontStyle.Normal;
+
+    public async void Rename()
+    {
+        var renameWindow = new SymbolRefactorWindow(this);
+        await renameWindow.ShowDialog(ApiVault.Get().GetMainWindow());
     }
     
     public void Rename(string newName)

--- a/SkEditor/Utilities/Parser/Elements/CodeVariable.cs
+++ b/SkEditor/Utilities/Parser/Elements/CodeVariable.cs
@@ -1,13 +1,15 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel;
 using System.Text.RegularExpressions;
 using Avalonia.Media;
 using AvaloniaEdit.Editing;
+using CommunityToolkit.Mvvm.ComponentModel;
 using SkEditor.API;
 using SkEditor.Views;
 
 namespace SkEditor.Utilities.Parser;
 
-public class CodeVariable : INameableCodeElement
+public class CodeVariable : ObservableObject, INameableCodeElement
 {
     public CodeSection Section { get; private set; }
     
@@ -46,12 +48,6 @@ public class CodeVariable : INameableCodeElement
     }
     
     public FontStyle Style => IsLocal ? FontStyle.Italic : FontStyle.Normal;
-
-    public async void Rename()
-    {
-        var renameWindow = new SymbolRefactorWindow(this);
-        await renameWindow.ShowDialog(ApiVault.Get().GetMainWindow());
-    }
     
     public void Rename(string newName)
     {
@@ -115,6 +111,13 @@ public class CodeVariable : INameableCodeElement
                 section.Parse();
             }
         }
+    }
+    
+    public async void Rename()
+    {
+        var renameWindow = new SymbolRefactorWindow(this);
+        await renameWindow.ShowDialog(ApiVault.Get().GetMainWindow());
+        Section.Parser.Parse();
     }
 
     public string GetNameDisplay()

--- a/SkEditor/Utilities/Parser/INameableCodeElement.cs
+++ b/SkEditor/Utilities/Parser/INameableCodeElement.cs
@@ -1,0 +1,18 @@
+﻿namespace SkEditor.Utilities.Parser;
+
+/// <summary>
+/// Represent a parsed code element that is named (variables, functions, etc) and thus can be renamed.
+/// </summary>
+public interface INameableCodeElement
+{
+    
+    public string Name { get; }
+    
+    public void Rename(string newName);
+    
+    public virtual string GetNameDisplay()
+    {
+        return Name;
+    }
+    
+}

--- a/SkEditor/Utilities/SidebarPanel.cs
+++ b/SkEditor/Utilities/SidebarPanel.cs
@@ -12,6 +12,8 @@ public abstract class SidebarPanel
     public abstract UserControl Content { get; }
     public abstract IconSource Icon { get; }
     public abstract bool IsDisabled { get; }
+
+    public virtual int DesiredWidth { get; } = 250;
     
     public virtual void OnOpen()
     {

--- a/SkEditor/Views/MainWindow.axaml.cs
+++ b/SkEditor/Views/MainWindow.axaml.cs
@@ -13,6 +13,7 @@ using SkEditor.Utilities.Styling;
 using SkEditor.Utilities.Syntax;
 using System.Collections.Generic;
 using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel.__Internals;
 
 namespace SkEditor.Views;
 
@@ -36,6 +37,7 @@ public partial class MainWindow : AppWindow
     {
         TabControl.AddTabButtonCommand = new RelayCommand(FileHandler.NewFile);
         TabControl.TabCloseRequested += (sender, e) => FileHandler.CloseFile(e);
+        TabControl.SelectionChanged += (_, _) => SideBar.ParserPanel.Panel.ParseCurrentFile();
         TemplateApplied += OnWindowLoaded;
         Closing += OnClosing;
 

--- a/SkEditor/Views/SymbolRefactorWindow.axaml
+++ b/SkEditor/Views/SymbolRefactorWindow.axaml
@@ -1,0 +1,26 @@
+﻿<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="150"
+        Width="300" Height="150" MinWidth="300" MinHeight="150"
+        x:Class="SkEditor.Views.SymbolRefactorWindow"
+        Icon="/Assets/SkEditor.ico"
+        Title="{DynamicResource WindowTitleRefactor}" CanResize="False" WindowStartupLocation="CenterOwner">
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceInclude Source="avares://SkEditor/Styles/OnlyCloseButtonWindow.axaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Window.Resources>
+    
+    <Grid RowDefinitions="Auto,*" Margin="10">
+        <StackPanel Grid.Row="0" HorizontalAlignment="Stretch" VerticalAlignment="Center" Spacing="5">
+            <TextBlock Name="RenameText">Rename '{_test}'</TextBlock>
+            <TextBox Name="NameBox"></TextBox>
+        </StackPanel>
+        <Button Name="RefactorButton" Grid.Row="1" HorizontalAlignment="Right" VerticalAlignment="Bottom" Content="Refactor" Width="100" Height="30"/>
+    </Grid>
+    
+</Window>

--- a/SkEditor/Views/SymbolRefactorWindow.axaml.cs
+++ b/SkEditor/Views/SymbolRefactorWindow.axaml.cs
@@ -1,5 +1,6 @@
 ﻿using CommunityToolkit.Mvvm.Input;
 using FluentAvalonia.UI.Windowing;
+using SkEditor.API;
 using SkEditor.Utilities;
 using SkEditor.Utilities.Parser;
 
@@ -22,5 +23,7 @@ public partial class SymbolRefactorWindow : AppWindow
     {
         Element.Rename(NameBox.Text);
         Close();
+        
+        ApiVault.Get().GetMainWindow().SideBar.ParserPanel.Panel.ParseCurrentFile();
     }
 }

--- a/SkEditor/Views/SymbolRefactorWindow.axaml.cs
+++ b/SkEditor/Views/SymbolRefactorWindow.axaml.cs
@@ -1,0 +1,26 @@
+﻿using CommunityToolkit.Mvvm.Input;
+using FluentAvalonia.UI.Windowing;
+using SkEditor.Utilities;
+using SkEditor.Utilities.Parser;
+
+namespace SkEditor.Views;
+
+public partial class SymbolRefactorWindow : AppWindow
+{
+    public INameableCodeElement Element { get; }
+    public SymbolRefactorWindow(INameableCodeElement element)
+    {
+        InitializeComponent();
+        Element = element;
+
+        RenameText.Text = Translation.Get("RefactorWindowRefactorBoxName", element.GetNameDisplay());
+        NameBox.Text = element.Name;
+        RefactorButton.Command = new RelayCommand(Refactor);
+    }
+    
+    private void Refactor()
+    {
+        Element.Rename(NameBox.Text);
+        Close();
+    }
+}


### PR DESCRIPTION
Allow right-clicking on variables and options in an opened script for renaming it according to the context.

In the backend, it's a pretty simple code parser that can organize elements per file. It'll be really useful in projects to rename a function across multiple files for instance.