### PR TITLE
Enter key support & focus on docs search query

### DIFF
--- a/SkEditor/Controls/Docs/DocumentationControl.axaml
+++ b/SkEditor/Controls/Docs/DocumentationControl.axaml
@@ -26,7 +26,7 @@
             
             <StackPanel Grid.Row="1" Grid.Column="0" Spacing="5" Margin="5" HorizontalAlignment="Stretch">
                 <TextBlock Text="{DynamicResource DocumentationWindowSearchQuery}" />
-                <TextBox Text="{Binding SearchData.Query, Mode=TwoWay}"/>
+                <TextBox Name="SearchQueryInput" Text="{Binding SearchData.Query, Mode=TwoWay}"/>
             </StackPanel>
             
             <StackPanel Grid.Row="1" Grid.Column="1" Spacing="5" Margin="5" HorizontalAlignment="Stretch">

--- a/SkEditor/Controls/Docs/DocumentationControl.axaml.cs
+++ b/SkEditor/Controls/Docs/DocumentationControl.axaml.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using CommunityToolkit.Mvvm.Input;
 using FluentAvalonia.UI.Controls;
@@ -25,6 +26,13 @@ public partial class DocumentationControl : UserControl
         AssignCommands();
         AddItems();
         LoadingInformation.IsVisible = false;
+        SearchQueryInput.Loaded += (sender, e) => SearchQueryInput.Focus();
+
+        KeyDown += (sender, e) =>
+        {
+            if (e.Key == Key.Enter) SearchButtonClick(sender, e);
+        };
+
     }
 
     public void AssignCommands()


### PR DESCRIPTION
This PR adds support of Enter key & the focus on the documentation search query as it loads.