### PR TITLE
Context menu

### DIFF
--- a/SkEditor/Utilities/Files/FileBuilder.cs
+++ b/SkEditor/Utilities/Files/FileBuilder.cs
@@ -240,7 +240,7 @@ public class FileBuilder
         return editor;
     }
 
-    private static MenuFlyout GetContextMenu(TextEditor editor)
+    public static MenuFlyout GetContextMenu(TextEditor editor)
     {
         var commands = new[]
         {
@@ -251,6 +251,7 @@ public class FileBuilder
             new { Header = "MenuHeaderRedo", Command = new RelayCommand(() => editor.Redo()), Icon = Symbol.Redo },
             new { Header = "MenuHeaderDuplicate", Command = new RelayCommand(() => CustomCommandsHandler.OnDuplicateCommandExecuted(editor.TextArea)), Icon = Symbol.Copy },
             new { Header = "MenuHeaderComment", Command = new RelayCommand(() => CustomCommandsHandler.OnCommentCommandExecuted(editor.TextArea)), Icon = Symbol.Comment },
+            new { Header = "MenuHeaderGoToLine", Command = new RelayCommand(() => new GoToLine().ShowDialog(ApiVault.Get().GetMainWindow())), Icon = Symbol.Find },
             new { Header = "MenuHeaderDelete", Command = new RelayCommand(editor.Delete), Icon = Symbol.Delete },
             new { Header = "MenuHeaderRefactor", Command = new RelayCommand(() => CustomCommandsHandler.OnRefactorCommandExecuted(editor)), Icon = Symbol.Rename },
         };

--- a/SkEditor/Views/Settings/GeneralPage.axaml.cs
+++ b/SkEditor/Views/Settings/GeneralPage.axaml.cs
@@ -8,6 +8,7 @@ using SkEditor.Utilities;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using SkEditor.Utilities.Files;
 
 namespace SkEditor.Views.Settings;
 public partial class GeneralPage : UserControl
@@ -35,7 +36,16 @@ public partial class GeneralPage : UserControl
         {
             string language = LanguageComboBox.SelectedItem.ToString();
             ApiVault.Get().GetAppConfig().Language = language;
-            Dispatcher.UIThread.InvokeAsync(() => Translation.ChangeLanguage(language));
+            Dispatcher.UIThread.InvokeAsync(() => 
+            {
+                Translation.ChangeLanguage(language);
+
+                // Regenerate the text editor context menu
+                // TODO: Context menu language doesn't change, when user has documentation tab opened.
+                if (!ApiVault.Get().IsFileOpen()) return;
+                TextEditor editor = ApiVault.Get().GetTextEditor();
+                editor.ContextFlyout = FileBuilder.GetContextMenu(editor);
+            });
         };
     }
 


### PR DESCRIPTION
This PR fixes the right click context menu's language not refreshing after changing language; also adds 'Go to line' button to it.
Context menu still doesn't refresh if user changes language while in documentation tab.