### PR TITLE
Make use of gui slot value when generating with skript-gui

### DIFF
--- a/SkEditor/Views/Generators/Gui/Generation.cs
+++ b/SkEditor/Views/Generators/Gui/Generation.cs
@@ -116,7 +116,7 @@ public class Generation
             if (pair.Value.HaveExampleAction)
             {
                 code.Append(':');
-                code.Append($"\n\t\t\tsend \"You clicked on slot {pair.Key}\"");
+                code.Append($"\n\t\t\tsend \"You clicked on slot %gui slot%\"");
             }
         }
         code.Append("\n\topen the last gui for {_p}");


### PR DESCRIPTION
This allows the user to simply change the item's gui slot, without requiring to change the message manually.