### PR TITLE
Add Prefix option to command generator & fix ambiguous call in Folder.cs

### DIFF
--- a/SkEditor/Languages/Chinese.xaml
+++ b/SkEditor/Languages/Chinese.xaml
@@ -176,6 +176,7 @@
 
     <!-- 命令生成器 -->
     <system:String x:Key="CommandGeneratorName">名称</system:String>
+    <system:String x:Key="CommandGeneratorPrefix">前缀</system:String>
     <system:String x:Key="CommandGeneratorPermission">权限</system:String>
     <system:String x:Key="CommandGeneratorNoPermissionMessage">无权限消息</system:String>
     <system:String x:Key="CommandGeneratorAliases">别名</system:String>

--- a/SkEditor/Languages/English.xaml
+++ b/SkEditor/Languages/English.xaml
@@ -385,6 +385,7 @@
 
     <!-- Command Generator -->
     <system:String x:Key="CommandGeneratorName">Name</system:String>
+    <system:String x:Key="CommandGeneratorPrefix">Prefix</system:String>
     <system:String x:Key="CommandGeneratorPermission">Permission</system:String>
     <system:String x:Key="CommandGeneratorNoPermissionMessage">No permission message</system:String>
     <system:String x:Key="CommandGeneratorAliases">Aliases</system:String>

--- a/SkEditor/Languages/French.xaml
+++ b/SkEditor/Languages/French.xaml
@@ -370,6 +370,7 @@
 
     <!-- Générateur de commande -->
     <system:String x:Key="CommandGeneratorName">Nom</system:String>
+    <system:String x:Key="CommandGeneratorPrefix">Préfixe</system:String>
     <system:String x:Key="CommandGeneratorPermission">Permission</system:String>
     <system:String x:Key="CommandGeneratorNoPermissionMessage">Message en cas d'absence de permission</system:String>
     <system:String x:Key="CommandGeneratorAliases">Alias</system:String>

--- a/SkEditor/Languages/German.xaml
+++ b/SkEditor/Languages/German.xaml
@@ -383,6 +383,7 @@
 
     <!-- Command Generator -->
     <system:String x:Key="CommandGeneratorName">Name</system:String>
+    <system:String x:Key="CommandGeneratorPrefix">Präfix</system:String>
     <system:String x:Key="CommandGeneratorPermission">Berechtigung</system:String>
     <system:String x:Key="CommandGeneratorNoPermissionMessage">Keine Berechtigungsnachricht</system:String>
     <system:String x:Key="CommandGeneratorAliases">Aliase</system:String>

--- a/SkEditor/Languages/Hungarian.xaml
+++ b/SkEditor/Languages/Hungarian.xaml
@@ -363,6 +363,7 @@
 
     <!-- Command Generator (Parancs Generátor) -->
     <system:String x:Key="CommandGeneratorName">Név</system:String>
+    <system:String x:Key="CommandGeneratorPrefix">Prefix</system:String>
     <system:String x:Key="CommandGeneratorPermission">Jogosultság</system:String>
     <system:String x:Key="CommandGeneratorNoPermissionMessage">Nincs jogosultság üzenet</system:String>
     <system:String x:Key="CommandGeneratorAliases">Aliasok</system:String>

--- a/SkEditor/Languages/Italian.xaml
+++ b/SkEditor/Languages/Italian.xaml
@@ -370,6 +370,7 @@
 
     <!-- Command Generator -->
     <system:String x:Key="CommandGeneratorName">Nome</system:String>
+    <system:String x:Key="CommandGeneratorPrefix">Prefisso</system:String>
     <system:String x:Key="CommandGeneratorPermission">Permesso</system:String>
     <system:String x:Key="CommandGeneratorNoPermissionMessage">Messaggio di Nessun permesso</system:String>
     <system:String x:Key="CommandGeneratorAliases">Alias</system:String>

--- a/SkEditor/Languages/Korean.xaml
+++ b/SkEditor/Languages/Korean.xaml
@@ -221,6 +221,7 @@
 
     <!-- Command Generator -->
     <system:String x:Key="CommandGeneratorName">이름</system:String>
+    <system:String x:Key="CommandGeneratorPrefix">접두사</system:String>
     <system:String x:Key="CommandGeneratorPermission">권한</system:String>
     <system:String x:Key="CommandGeneratorNoPermissionMessage">권한 오류 메세지 없음</system:String>
     <system:String x:Key="CommandGeneratorAliases">별칭</system:String>

--- a/SkEditor/Languages/Polish.xaml
+++ b/SkEditor/Languages/Polish.xaml
@@ -385,6 +385,7 @@
 
     <!-- Command Generator -->
     <system:String x:Key="CommandGeneratorName">Nazwa</system:String>
+    <system:String x:Key="CommandGeneratorPrefix">Prefiks</system:String>
     <system:String x:Key="CommandGeneratorPermission">Uprawnienie</system:String>
     <system:String x:Key="CommandGeneratorNoPermissionMessage">Wiadomość o braku uprawnień</system:String>
     <system:String x:Key="CommandGeneratorAliases">Aliasy</system:String>

--- a/SkEditor/Languages/Russian.xaml
+++ b/SkEditor/Languages/Russian.xaml
@@ -368,6 +368,7 @@
 
     <!-- Генератор команд -->
     <system:String x:Key="CommandGeneratorName">Имя</system:String>
+    <system:String x:Key="CommandGeneratorPrefix">Префикс</system:String>
     <system:String x:Key="CommandGeneratorPermission">Разрешение</system:String>
     <system:String x:Key="CommandGeneratorNoPermissionMessage">Сообщение об отсутствии разрешения</system:String>
     <system:String x:Key="CommandGeneratorAliases">Псевдонимы</system:String>

--- a/SkEditor/Languages/Spanish.xaml
+++ b/SkEditor/Languages/Spanish.xaml
@@ -175,6 +175,7 @@
 
     <!-- Generador de Comandos -->
     <system:String x:Key="CommandGeneratorName">Nombre</system:String>
+    <system:String x:Key="CommandGeneratorPrefix">Prefijo</system:String>
     <system:String x:Key="CommandGeneratorPermission">Permiso</system:String>
     <system:String x:Key="CommandGeneratorNoPermissionMessage">Mensaje sin permiso</system:String>
     <system:String x:Key="CommandGeneratorAliases">Alias</system:String>

--- a/SkEditor/Utilities/Projects/Elements/Folder.cs
+++ b/SkEditor/Utilities/Projects/Elements/Folder.cs
@@ -41,7 +41,7 @@ public partial class Folder : StorageElement
         if (string.IsNullOrEmpty(Name))
         {
             string[] segments = folder.Split(
-                [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+                new char[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar },
                 StringSplitOptions.RemoveEmptyEntries
             );
 

--- a/SkEditor/Views/Generators/CommandGenerator.axaml
+++ b/SkEditor/Views/Generators/CommandGenerator.axaml
@@ -14,6 +14,10 @@
                 <TextBox Name="NameTextBox" />
             </StackPanel>
             <StackPanel Spacing="5">
+                <TextBlock Text="{DynamicResource CommandGeneratorPrefix}" />
+                <TextBox Name="PrefixTextBox" />
+            </StackPanel>
+            <StackPanel Spacing="5">
                 <TextBlock Text="{DynamicResource CommandGeneratorPermission}" />
                 <TextBox Name="PermissionTextBox" />
             </StackPanel>

--- a/SkEditor/Views/Generators/CommandGenerator.axaml.cs
+++ b/SkEditor/Views/Generators/CommandGenerator.axaml.cs
@@ -55,6 +55,7 @@ public partial class CommandGenerator : AppWindow
 
         code.Append($"command /{NameTextBox.Text}:");
 
+        AppendIfExists(ref code, "\n\tprefix: {0}", PrefixTextBox.Text);
         AppendIfExists(ref code, "\n\tpermission: {0}", PermissionTextBox.Text);
         AppendIfExists(ref code, "\n\tpermission message: {0}", NoPermissionMessageTextBox.Text);
         AppendIfExists(ref code, "\n\taliases: {0}", AliasesTextBox.Text);


### PR DESCRIPTION
I honestly just wanted the option to directly add a prefix in the GUI so here we are.
There is just the small issue that analyzer doesn't seem to correctly format the command component.
<img width="400" height="233" alt="image" src="https://github.com/user-attachments/assets/ef7a29c8-776b-471a-a621-a7aab35f0b7e" />
