### PR TITLE
Translate 'Marketplace' to 'Mercado' in Spanish.xaml

### DIFF
--- a/SkEditor/Languages/Spanish.xaml
+++ b/SkEditor/Languages/Spanish.xaml
@@ -12,7 +12,7 @@
     <system:String x:Key="WindowTitleGuiGenerator">Generar GUI</system:String>
     <system:String x:Key="WindowTitleCommandGenerator">Generar comando</system:String>
     <system:String x:Key="WindowTitleItemSelector">Seleccionar ítem</system:String>
-    <system:String x:Key="WindowTitleMarketplace">Marketplace</system:String>
+    <system:String x:Key="WindowTitleMarketplace">Mercado</system:String>
 
     <!-- Encabezados de Menú -->
     <system:String x:Key="MenuHeaderFile">Archivo</system:String>


### PR DESCRIPTION
I would use "resources" → Recursos, because in Spanish Market isn't a place with free extensions.

Additionally the check for updates configuration option does not have translation in this file.