### PR TITLE
Fix cursor jumping away when switching keyboard layout

### DIFF
--- a/SkEditor/Views/Windows/MainWindow.axaml.cs
+++ b/SkEditor/Views/Windows/MainWindow.axaml.cs
@@ -6,6 +6,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Threading;
+using AvaloniaEdit;
 using CommunityToolkit.Mvvm.Input;
 using FluentAvalonia.UI.Controls;
 using FluentAvalonia.UI.Windowing;
@@ -103,6 +104,28 @@ public partial class MainWindow : AppWindow
         };
 
         AddHandler(DragDrop.DropEvent, FileHandler.FileDropAction);
+        
+        AddHandler(KeyUpEvent, (_, e) =>
+        {
+            if (e.Key is not (Key.LeftAlt or Key.RightAlt))
+            {
+                return;
+            }
+            
+            TextEditor? editor = SkEditorAPI.Files.GetCurrentOpenedFile()?.Editor;
+            if (editor == null)
+            {
+                return;
+            }
+            
+
+            if (editor.TextArea.IsFocused || editor.IsFocused)
+            {
+                e.Handled = true;
+
+                Dispatcher.UIThread.Post(() => editor.TextArea.Focus());
+            }
+        }, RoutingStrategies.Tunnel);
     }
 
     public void ReloadUiOfAddons()

--- a/SkEditor/Views/Windows/MainWindow.axaml.cs
+++ b/SkEditor/Views/Windows/MainWindow.axaml.cs
@@ -26,6 +26,7 @@ public partial class MainWindow : AppWindow
     private readonly SplashScreen? _splashScreen;
     private bool _isFullyLoaded;
     private WindowState _preFullScreenState;
+    private bool _layoutSwitchDetected;
 
     public MainWindow(SplashScreen? splashScreen = null)
     {
@@ -104,26 +105,50 @@ public partial class MainWindow : AppWindow
         };
 
         AddHandler(DragDrop.DropEvent, FileHandler.FileDropAction);
-        
+
+        AddHandler(KeyDownEvent, (_, e) =>
+        {
+            if (e.Key is Key.LeftAlt or Key.RightAlt && e.KeyModifiers.HasFlag(KeyModifiers.Shift))
+            {
+                _layoutSwitchDetected = true;
+            }
+            else if (e.Key is Key.LeftShift or Key.RightShift && e.KeyModifiers.HasFlag(KeyModifiers.Alt))
+            {
+                _layoutSwitchDetected = true;
+            }
+            else if (e.Key is Key.LeftShift or Key.RightShift && e.KeyModifiers.HasFlag(KeyModifiers.Control))
+            {
+                _layoutSwitchDetected = true;
+            }
+            else if (e.Key is Key.LeftCtrl or Key.RightCtrl && e.KeyModifiers.HasFlag(KeyModifiers.Shift))
+            {
+                _layoutSwitchDetected = true;
+            }
+        }, RoutingStrategies.Tunnel);
+
         AddHandler(KeyUpEvent, (_, e) =>
         {
-            if (e.Key is not (Key.LeftAlt or Key.RightAlt))
+            bool isLayoutSwitchKey = e.Key is Key.LeftAlt or Key.RightAlt 
+                                     or Key.LeftShift or Key.RightShift 
+                                     or Key.LeftCtrl or Key.RightCtrl;
+            
+            if (!isLayoutSwitchKey || !_layoutSwitchDetected)
             {
                 return;
             }
-            
-            TextEditor? editor = SkEditorAPI.Files.GetCurrentOpenedFile()?.Editor;
-            if (editor == null)
-            {
-                return;
-            }
-            
 
-            if (editor.TextArea.IsFocused || editor.IsFocused)
+            _layoutSwitchDetected = false;
+
+            OpenedFile? currentFile = SkEditorAPI.Files.GetCurrentOpenedFile();
+            if (currentFile?.Editor?.TextArea is not { } textArea)
+            {
+                return;
+            }
+
+            if (textArea.IsFocused)
             {
                 e.Handled = true;
-
-                Dispatcher.UIThread.Post(() => editor.TextArea.Focus());
+                Dispatcher.UIThread.Post(() => textArea.Focus());
             }
         }, RoutingStrategies.Tunnel);
     }


### PR DESCRIPTION
Hey! Taking another shot at this after your feedback on the previous PR.

You were right - blocking all Alt keypresses was a bad idea. So I rewrote it
completely. Now it only kicks in when you actually use a layout switch combo
(Alt+Shift or Ctrl+Shift), not when you're just trying to open the menu.

Basically I track when these combos are pressed (KeyDown) and only then block
the menu activation on KeyUp. Regular Alt still works fine for accessing menus.

I use Russian + English daily so this bug was driving me crazy, had to fix it
myself instead of waiting. Tested it pretty thoroughly - layout switching works,
menu shortcuts work, everything seems good.